### PR TITLE
Only fetch approved organizations, handle non-error events in fetch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.8'
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Check syntax

--- a/ckanext/statistics/fanstatic/javascript/data/api.js
+++ b/ckanext/statistics/fanstatic/javascript/data/api.js
@@ -23,7 +23,7 @@ Api.prototype.getAllData = function (callback, delay) {
   self._stepLoaded(self._texts.loadOrganizations, 66.1);
 
   return Promise.all([
-    self.get('group_tree'),
+    self.get('group_tree?only_approved=true'),
     self.get('group_list?all_fields=true&include_extras=true'),
     self.get('get_all_public_datasets'),
     self.get('ckanext_showcase_list?include_private=false')
@@ -64,7 +64,12 @@ Api.prototype.get = function(endPoint) {
   return new Promise(function(resolve, reject) {
     d3.json(url).get(function (error, response) {
       if (error) {
-        return reject(error);
+        if (error.type == 'error') {
+          return reject(error);
+        } else {
+          // A non-error event, keep trying
+          return;
+        }
       }
       return resolve(response.result || []);
     });


### PR DESCRIPTION
- Added `only_approved` parameter to `group_tree` action call to hint requesting only approved organizations
- d3.json sometimes puts non-error events like load into error. Check that the error is actually an error before rejecting the fetch