### PR TITLE
Remove leftover IRoutes mention

### DIFF
--- a/ckanext/statistics/plugin/__init__.py
+++ b/ckanext/statistics/plugin/__init__.py
@@ -19,7 +19,6 @@ else:
 
 class StatisticsPlugin(platform.MixinPlugin, plugins.SingletonPlugin, DefaultTranslation):
     plugins.implements(plugins.IConfigurer)
-    plugins.implements(plugins.IRoutes, inherit=True)
     if toolkit.check_ckan_version(min_version='2.5.0'):
         plugins.implements(plugins.ITranslation, inherit=True)
     plugins.implements(plugins.IActions)


### PR DESCRIPTION
- There was one unused `plugin.implements` for `IRoutes` left over from previous migration